### PR TITLE
feat(arm64/dts): configure GPIO5_IO26 for input on imx8mn-var-som-sym…

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mn-var-som-symphony.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mn-var-som-symphony.dts
@@ -92,6 +92,11 @@
 
 
 &iomuxc {
+	pinctrl_gpio5_io26: gpio526grp {
+		fsl,pins = <
+			MX8MN_IOMUXC_UART3_RXD_GPIO5_IO26		0x61
+		>;
+	};
 	pinctrl_captouch: captouchgrp {
 		fsl,pins = <
 			MX8MN_IOMUXC_SPDIF_RX_GPIO5_IO4			0xc0
@@ -449,7 +454,7 @@
 &uart3 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart3>;
-	status = "okay";
+	status = "disabled";
 };
 
 /* Console */


### PR DESCRIPTION
Configure GPIO5_IO26 for input on imx8mn-var-som-symphony
Previously, the pin  GPIO5_IO26 was not configured to handle input, which limited its usability for future applications.