### PR TITLE
fix: enable RTC communication on Var-Som Nano with Fika module

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mn-var-som-symphony.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mn-var-som-symphony.dts
@@ -332,6 +332,12 @@
 			line-name = "enet_sel";
 		};
 	};
+	/* DS1337 RTC module */
+	rtc@68 {
+		status = "okay";
+		compatible = "dallas,ds1337";
+		reg = <0x68>;
+	};
 };
 
 &i2c3 {
@@ -349,13 +355,6 @@
 		touchscreen-inverted-x;
 		touchscreen-inverted-y;
 		wakeup-source;
-	};
-
-	/* DS1337 RTC module */
-	rtc@68 {
-		status = "okay";
-		compatible = "dallas,ds1337";
-		reg = <0x68>;
 	};
 };
 


### PR DESCRIPTION
The Var-Som Nano was not communicating with the RTC module on the Fika board due to misconfiguration in the device tree source. This commit relocates the RTC module configuration from an incorrect node to the correct I2C node, ensuring proper initialization and communication. The RTC device used is the DS1337.